### PR TITLE
[STEP13] 대용량 트래픽 & 데이터 처리 : 기본과제

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
 	//추가
-	implementation ("jakarta.persistence:jakarta.persistence-api:3.1.0")
 	implementation ("org.hibernate.orm:hibernate-core:6.2.6.Final")
 	implementation ("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation ("org.springframework.boot:spring-boot-starter-validation")
@@ -72,4 +71,8 @@ tasks.withType<Test> {
 	useJUnitPlatform()
 	systemProperty("user.timezone", "UTC")
 	systemProperty ("spring.profiles.active", "test")
+}
+
+tasks.withType<JavaCompile> {
+	options.compilerArgs.add("-parameters")
 }

--- a/src/main/java/kr/hhplus/be/server/application/concert/ConcertRankingService.java
+++ b/src/main/java/kr/hhplus/be/server/application/concert/ConcertRankingService.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.application.concert;
+
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingRepository;
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConcertRankingService {
+
+    private final ConcertRankingRepository concertRankingRepository;
+
+    /**
+     * 콘서트 매진 시점을 기준으로 랭킹 점수를 저장합니다.
+     * 매진 시간(ms) = soldOutAt - openedAt
+     * score가 작을수록 빠른 매진입니다.
+     */
+    public void recordSoldOutTime(Long concertId, long soldOutAt, long openedAt) {
+        concertRankingRepository.saveSoldOutRanking(concertId, soldOutAt, openedAt);
+    }
+    /**
+     * 상위 N개의 콘서트 랭킹을 조회합니다.
+     * score가 낮을수록 빠른 매진입니다.
+     */
+    public List<ConcertRankingResult> getTopConcerts(int limit) {
+        return concertRankingRepository.getTopRankings(limit);
+    }
+    /**
+     * 오늘 랭킹 데이터를 초기화합니다.
+     */
+    public void clearTodayRanking() {
+        concertRankingRepository.clearTodayRanking();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/payment/PaymentCommandService.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/PaymentCommandService.java
@@ -2,17 +2,25 @@ package kr.hhplus.be.server.application.payment;
 
 import kr.hhplus.be.server.application.cash.CashCommandService;
 import kr.hhplus.be.server.application.cash.UseCashCommand;
+import kr.hhplus.be.server.application.concert.ConcertRankingService;
+import kr.hhplus.be.server.domain.concert.ConcertRepository;
 import kr.hhplus.be.server.domain.payment.Payment;
 import kr.hhplus.be.server.domain.payment.PaymentRepository;
 import kr.hhplus.be.server.domain.reservation.Reservation;
 import kr.hhplus.be.server.domain.reservation.ReservationRepository;
 import kr.hhplus.be.server.domain.reservation.ReservationStatus;
+import kr.hhplus.be.server.infrastructure.concert.ConcertSeatCountRedisRepository;
 import kr.hhplus.be.server.support.exception.CustomException;
 import kr.hhplus.be.server.support.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentCommandService {
@@ -20,6 +28,9 @@ public class PaymentCommandService {
     private final ReservationRepository reservationRepository;
     private final PaymentRepository paymentRepository;
     private final CashCommandService cashCommandService;
+    private final ConcertRankingService concertRankingService;
+    private final ConcertSeatCountRedisRepository concertSeatCountRedisRepository;
+    private final ConcertRepository concertRepository;
 
     /**
      * 결제 처리
@@ -46,7 +57,19 @@ public class PaymentCommandService {
         // 결제 객체 생성 및 결제 처리
         Payment payment = Payment.create(reservation, command.amount());
         payment.pay(); // 상태를 READY → PAID 로 변경
-        return paymentRepository.save(payment);
+        paymentRepository.save(payment);
+
+        // Redis 카운트 감소
+        // 4. 좌석 수 감소 (Redis)
+        Long concertId = reservation.getConcertSeat().getConcert().getId();
+        long remain = concertSeatCountRedisRepository.decrementRemainCount(concertId);
+        log.info("남은 좌석 수: {} (concertId={})", remain, concertId);
+
+        // 5. 매진이면 랭킹 기록
+        if (remain <= 0) {
+            recordSoldOutRanking(concertId, reservation.getConcertSeat().getConcert().getConcertDateTime());
+        }
+        return payment;
     }
 
     /**
@@ -59,5 +82,18 @@ public class PaymentCommandService {
 
         payment.cancel(); // 내부 상태 변경
         return paymentRepository.save(payment);
+    }
+
+    private void recordSoldOutRanking(Long concertId, LocalDateTime concertDateTime) {
+        long soldOutAtMillis = System.currentTimeMillis();
+        long openedAtMillis = concertDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        long duration = soldOutAtMillis - openedAtMillis;
+
+        // 매진 시간이 오픈 시간보다 빠른 경우 저장 생략
+        if (duration < 0) {
+            log.warn("❗ 매진 시간보다 오픈 시간이 늦어 랭킹 저장을 생략합니다. concertId={}, duration={}ms", concertId, duration);
+            return;
+        }
+        concertRankingService.recordSoldOutTime(concertId, soldOutAtMillis, openedAtMillis);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/concert/ConcertSeatCountRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/ConcertSeatCountRepository.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.domain.concert;
+
+public interface ConcertSeatCountRepository {
+    /**
+     * 콘서트 좌석 수를 1 감소시킵니다.
+     * @param concertId 콘서트 ID
+     * @return 감소 후 남은 좌석 수
+     */
+    long decrementRemainCount(Long concertId);
+
+    /**
+     * 콘서트 좌석 수를 1 증가시킵니다.
+     * @param concertId 콘서트 ID
+     * @return 증가 후 좌석 수
+     */
+    long incrementRemainCount(Long concertId);
+
+    /**
+     * 좌석 수를 조회합니다.
+     */
+    long getRemainCount(Long concertId);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/concert/ranking/ConcertRankingRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/ranking/ConcertRankingRepository.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.domain.concert.ranking;
+
+import java.util.List;
+
+public interface ConcertRankingRepository {
+
+    /**
+     * 콘서트가 매진되었을 때, 매진까지 걸린 시간을 랭킹에 기록합니다.
+     * 점수(score)는 매진까지 걸린 시간(ms)이며, 낮을수록 빠른 매진입니다.
+     *
+     * @param concertId 콘서트 ID
+     * @param soldOutAtMillis 매진 시각 (밀리초)
+     * @param openedAtMillis 오픈 시각 (밀리초)
+     */
+    void saveSoldOutRanking(Long concertId, long soldOutAtMillis, long openedAtMillis);
+
+    /**
+     * 빠른 매진 순으로 상위 콘서트 목록을 조회합니다.
+     *
+     * @param limit 최대 조회 수
+     * @return 빠른 매진 랭킹 결과 목록
+     */
+    List<ConcertRankingResult> getTopRankings(int limit);
+
+    /**
+     * 오늘 날짜 기준 랭킹 데이터를 초기화합니다.
+     */
+    void clearTodayRanking();
+}

--- a/src/main/java/kr/hhplus/be/server/domain/concert/ranking/ConcertRankingResult.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/ranking/ConcertRankingResult.java
@@ -1,0 +1,3 @@
+package kr.hhplus.be.server.domain.concert.ranking;
+
+public record ConcertRankingResult(Long concertId, Double soldOutDurationMillis) { }

--- a/src/main/java/kr/hhplus/be/server/domain/concert/ranking/DailyConcertRanking.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/ranking/DailyConcertRanking.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.domain.concert.ranking;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import lombok.*;
+import jakarta.persistence.Id;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "daily_concert_ranking")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DailyConcertRanking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long concertId;
+
+    private double soldOutDurationMillis;
+
+    private LocalDate rankingDate;
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/concert/ConcertRankingRedisRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/concert/ConcertRankingRedisRepository.java
@@ -1,0 +1,67 @@
+package kr.hhplus.be.server.infrastructure.concert;
+
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingRepository;
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ConcertRankingRedisRepository implements ConcertRankingRepository {
+
+    private static final String RANKING_KEY_PREFIX = "concert-soldout-ranking:";
+    private static final long TTL_SECONDS = 60 * 60 * 24; // 1일
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void saveSoldOutRanking(Long concertId, long soldOutAtMillis, long openedAtMillis) {
+        long duration = soldOutAtMillis - openedAtMillis; // 매진까지 걸린 시간
+        String key = getTodayKey();
+
+        redisTemplate.opsForZSet().add(key, String.valueOf(concertId), duration);
+        redisTemplate.expire(key, Duration.ofSeconds(TTL_SECONDS));
+        log.info("매진 랭킹 저장: concertId={}, duration={}ms", concertId, duration);
+    }
+
+    @Override
+    public List<ConcertRankingResult> getTopRankings(int limit) {
+        String key = getTodayKey();
+        Set<ZSetOperations.TypedTuple<String>> range =
+                redisTemplate.opsForZSet().rangeWithScores(key, 0, limit - 1);
+
+        if (range == null || range.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return range.stream()
+                .map(tuple -> new ConcertRankingResult(
+                        Long.valueOf(tuple.getValue()),
+                        tuple.getScore()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void clearTodayRanking() {
+        String key = getTodayKey();
+        Boolean deleted = redisTemplate.delete(key);
+        log.info("오늘 랭킹 초기화: key={}, deleted={}", key, deleted);
+    }
+
+    private String getTodayKey() {
+        return RANKING_KEY_PREFIX + LocalDate.now().format(DateTimeFormatter.ISO_DATE);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/concert/ConcertSeatCountRedisRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/concert/ConcertSeatCountRedisRepository.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.infrastructure.concert;
+
+import kr.hhplus.be.server.domain.concert.ConcertSeatCountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ConcertSeatCountRedisRepository implements ConcertSeatCountRepository {
+
+    private static final String REMAIN_KEY_PREFIX = "concert:remain-seats:";
+    private final StringRedisTemplate redisTemplate;
+
+    private String getKey(Long concertId) {
+        return REMAIN_KEY_PREFIX + concertId;
+    }
+
+    @Override
+    public long decrementRemainCount(Long concertId) {
+        Long result = redisTemplate.opsForValue().decrement(getKey(concertId));
+        if (result == null) throw new IllegalStateException("Redis decrement 실패");
+        return result;
+    }
+
+    @Override
+    public long incrementRemainCount(Long concertId) {
+        Long result = redisTemplate.opsForValue().increment(getKey(concertId));
+        if (result == null) throw new IllegalStateException("Redis increment 실패");
+        return result;
+    }
+
+    @Override
+    public long getRemainCount(Long concertId) {
+        String value = redisTemplate.opsForValue().get(getKey(concertId));
+        return (value != null) ? Long.parseLong(value) : 0L;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/concert/DailyConcertRankingJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/concert/DailyConcertRankingJpaRepository.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.infrastructure.concert;
+
+import kr.hhplus.be.server.domain.concert.ranking.DailyConcertRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyConcertRankingJpaRepository extends JpaRepository<DailyConcertRanking, Long> {
+
+    List<DailyConcertRanking> findAllByRankingDate(LocalDate rankingDate);
+
+    boolean existsByConcertIdAndRankingDate(Long concertId, LocalDate rankingDate);
+}

--- a/src/main/java/kr/hhplus/be/server/support/filter/LoggingFilter.java
+++ b/src/main/java/kr/hhplus/be/server/support/filter/LoggingFilter.java
@@ -59,6 +59,12 @@ public class LoggingFilter implements Filter {
         String method = request.getMethod();
         String uri = request.getRequestURI();
 
+        try {
+            request.getParameterMap(); // 또는 request.getInputStream().readAllBytes();
+        } catch (Exception e) {
+            log.warn("Request content 초기화 실패", e);
+        }
+
         if ("GET".equalsIgnoreCase(method)) {
             log.info("[Request] {} {}", method, uri);
         } else {

--- a/src/main/java/kr/hhplus/be/server/support/scheduler/ConcertDailyRankingScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/support/scheduler/ConcertDailyRankingScheduler.java
@@ -1,0 +1,47 @@
+package kr.hhplus.be.server.support.scheduler;
+
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingRepository;
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingResult;
+import kr.hhplus.be.server.domain.concert.ranking.DailyConcertRanking;
+import kr.hhplus.be.server.infrastructure.concert.DailyConcertRankingJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertDailyRankingScheduler {
+
+    private final ConcertRankingRepository concertRankingRepository;
+    private final DailyConcertRankingJpaRepository dailyRankingJpaRepository;
+
+    /**
+     * 매일 자정에 Redis에 저장된 콘서트 랭킹을 DB로 저장합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00:00
+    @Transactional
+    public void saveTodayRankings() {
+        log.info("일간 콘서트 랭킹 저장 시작");
+
+        List<ConcertRankingResult> topRankings = concertRankingRepository.getTopRankings(100);
+        LocalDate today = LocalDate.now();
+
+        List<DailyConcertRanking> entities = topRankings.stream()
+                .map(result -> new DailyConcertRanking(
+                        null,
+                        result.concertId(),
+                        result.soldOutDurationMillis(),
+                        today
+                ))
+                .toList();
+
+        dailyRankingJpaRepository.saveAll(entities);
+        log.info("일간 콘서트 랭킹 저장 완료: {}건", entities.size());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,14 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
-
+logging:
+  level:
+    root: INFO
+    org.springframework.web: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.data.redis.core: DEBUG
+    kr.hhplus: DEBUG
 ---
 
 spring:

--- a/src/test/java/kr/hhplus/be/server/application/concert/ConcertRankingServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/concert/ConcertRankingServiceTest.java
@@ -1,0 +1,76 @@
+package kr.hhplus.be.server.application.concert;
+
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingRepository;
+import kr.hhplus.be.server.domain.concert.ranking.ConcertRankingResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConcertRankingServiceTest {
+
+    @InjectMocks
+    private ConcertRankingService concertRankingService;
+
+    @Mock
+    private ConcertRankingRepository concertRankingRepository;
+
+    @Test
+    @DisplayName("매진 시점 기록이 랭킹 저장소에 정상적으로 기록된다")
+    void recordSoldOutTime_success() {
+        // given
+        Long concertId = 1L;
+        LocalDateTime openedAt = LocalDateTime.of(2025, 5, 15, 12, 0);
+        LocalDateTime soldOutAt = LocalDateTime.of(2025, 5, 15, 14, 0);
+
+        long expectedOpenMillis = openedAt.toEpochSecond(ZoneOffset.UTC) * 1000;
+        long expectedSoldMillis = soldOutAt.toEpochSecond(ZoneOffset.UTC) * 1000;
+
+        // when
+        concertRankingService.recordSoldOutTime(concertId, expectedSoldMillis, expectedOpenMillis);
+
+        // then
+        verify(concertRankingRepository).saveSoldOutRanking(eq(concertId), eq(expectedSoldMillis), eq(expectedOpenMillis));
+    }
+
+    @Test
+    @DisplayName("상위 N개의 콘서트 랭킹을 조회한다")
+    void getTopConcerts_success() {
+        // given
+        List<ConcertRankingResult> rankings = List.of(
+                new ConcertRankingResult(1L, 7200000.0),
+                new ConcertRankingResult(2L, 7500000.0)
+        );
+        when(concertRankingRepository.getTopRankings(2)).thenReturn(rankings);
+
+        // when
+        List<ConcertRankingResult> result = concertRankingService.getTopConcerts(2);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).concertId()).isEqualTo(1L);
+        assertThat(result.get(0).soldOutDurationMillis()).isEqualTo(7200000.0);
+    }
+
+    @Test
+    @DisplayName("오늘 랭킹 데이터를 초기화한다")
+    void clearTodayRanking_success() {
+        // when
+        concertRankingService.clearTodayRanking();
+
+        // then
+        verify(concertRankingRepository).clearTodayRanking();
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/support/scheduler/ConcertDailyRankingSchedulerTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/scheduler/ConcertDailyRankingSchedulerTest.java
@@ -1,0 +1,69 @@
+package kr.hhplus.be.server.support.scheduler;
+
+import kr.hhplus.be.server.domain.concert.ranking.DailyConcertRanking;
+import kr.hhplus.be.server.infrastructure.concert.DailyConcertRankingJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class ConcertDailyRankingSchedulerTest {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private ConcertDailyRankingScheduler scheduler;
+
+    @Autowired
+    private DailyConcertRankingJpaRepository rankingRepository;
+
+    private static final String RANKING_KEY = "concert-soldout-ranking:" + LocalDate.now();
+
+    @BeforeEach
+    void setUp() {
+        // Redis에 미리 랭킹 데이터 삽입
+        redisTemplate.opsForZSet().add(RANKING_KEY, "1", 5000);  // concertId=1, duration=5s
+        redisTemplate.opsForZSet().add(RANKING_KEY, "2", 8000);  // concertId=2, duration=8s
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(RANKING_KEY); // Redis 정리
+        rankingRepository.deleteAll();     // DB 정리
+    }
+
+    @Test
+    @DisplayName("일간 랭킹 저장: Redis -> DB")
+    void saveTodayRankings_success() {
+        // when
+        scheduler.saveTodayRankings();
+
+        // then
+        List<DailyConcertRanking> rankings = rankingRepository.findAll();
+        assertThat(rankings).hasSize(2);
+
+        assertThat(rankings)
+                .extracting(DailyConcertRanking::getConcertId)
+                .containsExactlyInAnyOrder(1L, 2L);
+
+        assertThat(rankings)
+                .extracting(DailyConcertRanking::getSoldOutDurationMillis)
+                .containsExactlyInAnyOrder(5000.0, 8000.0);
+    }
+}


### PR DESCRIPTION
## 🔗 커밋 링크

**랭킹 기능 적용**
- 빠른 매진 Redis 랭킹 기능 : 585cb96 1f7cfac
- 일일 랭킹 : b434160
- 실시간 랭킹, 일일 랭킹 조회 : 0320c36

**테스트 작성**
- c9dbc35

**환경 설정**
- 설정 파일 및 로깅/예외처리 : 2a1758e

---

## 🤔 리뷰 포인트(질문)

**리뷰 포인트 1**

현재 랭킹 시스템은 좌석이 모두 결제되었을 때 해당 시점의 매진 소요 시간을 Redis에 한 번만 기록하는 구조입니다. 
그런데 환불, 취소 후 재결제와 같은 경우도 랭킹 집계에 포함해야 하는지 고민이 됩니다..
그렇다면 매진 시점의 기준을 최초 매진으로 할지 최종 매진으로 할지 또는 복수 매진 기록을 모두 수집해야 하는지.. 판단이 어려운데 이러한 조건들을 어떻게 정의하고 제어하는 것이 바람직할까요? 


**리뷰 포인트 2**

실시간 Redis 랭킹과 DB 랭킹 간 정합성 보장 방식이 적절한가요?
현재 구조는 실시간 매진 기록을 Redis ZSet에 저장하고 하루 1회 스케줄러가 이를 DailyConcertRanking 테이블에 적재하는 방식입니다.
그런데 이 과정에서 Redis 데이터가 삭제되거나 갱신이 누락되는 경우 DB 랭킹과 실시간 랭킹 간에 불일치가 발생할 수 있을 것 같습니다.
이런 구조에서 Redis와 DB 간 랭킹 정합성을 어떤 방식으로 검증하거나 보완하는 게 좋은지 궁금합니다..!

---

## 📌 step13 branch
[step13-branch](https://github.com/uuununew/concert-system/tree/step13)

---

## 이번주 KPT 회고

### Keep
화이팅하기

### Problem


### Try